### PR TITLE
geom_alt props

### DIFF
--- a/data/421/202/159/421202159.geojson
+++ b/data/421/202/159/421202159.geojson
@@ -517,6 +517,9 @@
     },
     "wof:country":"SC",
     "wof:created":1459010107,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"54392fb7b8da5f536382c77a82915892",
     "wof:hierarchy":[
         {
@@ -527,7 +530,7 @@
         }
     ],
     "wof:id":421202159,
-    "wof:lastmodified":1566638937,
+    "wof:lastmodified":1582318662,
     "wof:name":"Victoria",
     "wof:parent_id":85678305,
     "wof:placetype":"locality",

--- a/data/856/326/61/85632661.geojson
+++ b/data/856/326/61/85632661.geojson
@@ -929,6 +929,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -980,6 +981,10 @@
     },
     "wof:country":"SC",
     "wof:country_alpha3":"SYC",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"80e3275cdb1d44fce09be1cf049d03f0",
     "wof:hierarchy":[
         {
@@ -996,7 +1001,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566638935,
+    "wof:lastmodified":1582318662,
     "wof:name":"Seychelles",
     "wof:parent_id":102193527,
     "wof:placetype":"country",

--- a/data/856/326/61/85632661.geojson
+++ b/data/856/326/61/85632661.geojson
@@ -929,7 +929,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1001,7 +1000,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1582318662,
+    "wof:lastmodified":1583205375,
     "wof:name":"Seychelles",
     "wof:parent_id":102193527,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.