### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/202/159/421202159.geojson
+++ b/data/421/202/159/421202159.geojson
@@ -28,14 +28,29 @@
     "name:ara_x_preferred":[
         "\u0641\u064a\u0643\u062a\u0648\u0631\u064a\u0627"
     ],
+    "name:arg_x_preferred":[
+        "Victoria"
+    ],
+    "name:ary_x_preferred":[
+        "\u06a4\u064a\u0643\u0637\u0648\u0631\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0641\u064a\u0643\u062a\u0648\u0631\u064a\u0627"
     ],
     "name:ast_x_preferred":[
         "Victoria"
     ],
+    "name:avk_x_preferred":[
+        "Victoria"
+    ],
     "name:aze_x_preferred":[
         "Viktoriya"
+    ],
+    "name:bak_x_preferred":[
+        "\u0412\u0438\u043a\u0442\u043e\u0440\u0438\u044f"
+    ],
+    "name:ban_x_preferred":[
+        "Victoria"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0412\u0456\u043a\u0442\u043e\u0440\u044b\u044f"
@@ -45,6 +60,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09ad\u09bf\u0995\u09cd\u099f\u09cb\u09b0\u09bf\u09af\u09bc\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u09ad\u09bf\u0995\u09cd\u09a4\u09cb\u09b0\u09bf\u09af\u09bc\u09be"
     ],
     "name:bod_x_preferred":[
         "\u0f5d\u0f72\u0f42\u0f0b\u0f50\u0f7c\u0f0b\u0f62\u0f72\u0f0b\u0f61\u0f0d"
@@ -121,6 +139,9 @@
     "name:fra_x_preferred":[
         "Victoria"
     ],
+    "name:frr_x_preferred":[
+        "Victoria"
+    ],
     "name:fry_x_preferred":[
         "Fiktoria"
     ],
@@ -145,6 +166,9 @@
     "name:hat_x_preferred":[
         "Viktorya"
     ],
+    "name:hau_x_preferred":[
+        "Biktoriya"
+    ],
     "name:hbs_x_preferred":[
         "Victoria"
     ],
@@ -165,6 +189,15 @@
     ],
     "name:hye_x_preferred":[
         "\u054e\u056b\u056f\u057f\u0578\u0580\u056b\u0561"
+    ],
+    "name:ido_x_preferred":[
+        "Victoria"
+    ],
+    "name:ile_x_preferred":[
+        "Victoria"
+    ],
+    "name:ina_x_preferred":[
+        "Victoria"
     ],
     "name:ind_x_preferred":[
         "Victoria"
@@ -205,6 +238,9 @@
     "name:lav_x_preferred":[
         "Viktorija"
     ],
+    "name:lij_x_preferred":[
+        "Vict\u00f2ria"
+    ],
     "name:lit_x_preferred":[
         "Viktorija"
     ],
@@ -220,6 +256,9 @@
     "name:mar_x_preferred":[
         "\u0935\u094d\u0939\u093f\u0915\u094d\u091f\u094b\u0930\u093f\u092f\u093e"
     ],
+    "name:mdf_x_preferred":[
+        "\u0412\u0438\u043a\u0442\u043e\u0440\u0438\u044f"
+    ],
     "name:mkd_x_preferred":[
         "\u0412\u0438\u043a\u0442\u043e\u0440\u0438\u0458\u0430"
     ],
@@ -231,6 +270,9 @@
     ],
     "name:msa_x_preferred":[
         "Victoria"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0648\u06cc\u06a9\u062a\u0648\u0631\u06cc\u0627"
     ],
     "name:nah_x_preferred":[
         "Victoria"
@@ -258,6 +300,9 @@
     ],
     "name:oci_x_preferred":[
         "Vict\u00f2ria"
+    ],
+    "name:olo_x_preferred":[
+        "Viktorii"
     ],
     "name:oss_x_preferred":[
         "\u0412\u0438\u043a\u0442\u043e\u0440\u0438"
@@ -295,6 +340,9 @@
     "name:slv_x_preferred":[
         "Viktorija"
     ],
+    "name:smn_x_preferred":[
+        "Victoria"
+    ],
     "name:sna_x_preferred":[
         "Victoria"
     ],
@@ -306,6 +354,9 @@
     ],
     "name:sqi_x_preferred":[
         "Viktoria"
+    ],
+    "name:srd_x_preferred":[
+        "Victoria"
     ],
     "name:srp_x_preferred":[
         "\u0412\u0438\u043a\u0442\u043e\u0440\u0438\u0458\u0430"
@@ -325,11 +376,17 @@
     "name:tel_x_preferred":[
         "\u0c35\u0c3f\u0c15\u0c4d\u0c1f\u0c4b\u0c30\u0c3f\u0c2f\u0c3e"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043a\u0442\u043e\u0440\u0438\u044f"
+    ],
     "name:tgl_x_preferred":[
         "Victoria"
     ],
     "name:tha_x_preferred":[
         "\u0e27\u0e34\u0e01\u0e15\u0e2d\u0e40\u0e23\u0e35\u0e22"
+    ],
+    "name:tha_x_variant":[
+        "\u0e27\u0e34\u0e01\u0e17\u0e2d\u0e40\u0e23\u0e35\u0e22"
     ],
     "name:tuk_x_preferred":[
         "Wiktori\u00fda"
@@ -390,6 +447,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7ef4\u591a\u5229\u4e9a"
+    ],
+    "name:zho_x_variant":[
+        "\u7dad\u591a\u5229\u4e9e"
     ],
     "name:zho_yue_x_preferred":[
         "\u7dad\u591a\u5229\u4e9e"
@@ -544,7 +604,7 @@
         }
     ],
     "wof:id":421202159,
-    "wof:lastmodified":1636495640,
+    "wof:lastmodified":1690860402,
     "wof:name":"Victoria",
     "wof:parent_id":85678305,
     "wof:placetype":"locality",

--- a/data/856/326/61/85632661.geojson
+++ b/data/856/326/61/85632661.geojson
@@ -28,11 +28,17 @@
     "mz:is_current":1,
     "mz:max_zoom":10.0,
     "mz:min_zoom":5.0,
+    "name:abk_x_preferred":[
+        "\u0421\u0435\u0438\u0448\u0435\u043b\u0442\u04d9\u0438 \u0410\u0434\u0433\u044c\u044b\u043b\u0431\u0436\u044c\u0430\u0445\u0430\u049b\u04d9\u0430"
+    ],
     "name:afr_x_preferred":[
         "Seychelle"
     ],
     "name:aka_x_preferred":[
         "Seyhy\u025bl"
+    ],
+    "name:aka_x_variant":[
+        "Seychelles"
     ],
     "name:als_x_preferred":[
         "Seychellen"
@@ -43,6 +49,12 @@
     "name:amh_x_variant":[
         "\u1232\u123c\u120d\u1235"
     ],
+    "name:ang_x_preferred":[
+        "Segscelliega"
+    ],
+    "name:anp_x_preferred":[
+        "\u0938\u0947\u0936\u0947\u0932\u094d\u0938"
+    ],
     "name:ara_x_preferred":[
         "\u0633\u064a\u0634\u0644"
     ],
@@ -52,6 +64,9 @@
     "name:arg_x_preferred":[
         "Seychelles"
     ],
+    "name:ary_x_preferred":[
+        "\u0633\u064a\u0634\u064a\u0644"
+    ],
     "name:arz_x_preferred":[
         "\u0633\u064a\u0634\u064a\u0644"
     ],
@@ -60,6 +75,9 @@
     ],
     "name:ast_x_variant":[
         "Seixeles"
+    ],
+    "name:avk_x_preferred":[
+        "Seycella"
     ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u0634\u0644"
@@ -82,6 +100,9 @@
     "name:bam_x_variant":[
         "Ses\u025bli"
     ],
+    "name:ban_x_preferred":[
+        "Seychelles"
+    ],
     "name:bar_x_preferred":[
         "Seychelln"
     ],
@@ -98,10 +119,14 @@
         "\u09b8\u09c7\u09b6\u09c7\u09b2"
     ],
     "name:ben_x_variant":[
-        "\u09b8\u09bf\u09b8\u09bf\u09b2\u09bf"
+        "\u09b8\u09bf\u09b8\u09bf\u09b2\u09bf",
+        "\u09b8\u09c7\u09b6\u09c7\u09b2\u09b8"
     ],
     "name:bho_x_preferred":[
         "\u0938\u0947\u0936\u0947\u0932\u094d\u0938"
+    ],
+    "name:bis_x_preferred":[
+        "Seisel"
     ],
     "name:bjn_x_preferred":[
         "Seychelles"
@@ -158,6 +183,9 @@
     "name:cor_x_preferred":[
         "Seychellys"
     ],
+    "name:cos_x_preferred":[
+        "Sexelles"
+    ],
     "name:cre_x_preferred":[
         "Repiblik Sesel"
     ],
@@ -165,6 +193,9 @@
         "Sey\u015feller"
     ],
     "name:cym_x_preferred":[
+        "Seychelles"
+    ],
+    "name:dag_x_preferred":[
         "Seychelles"
     ],
     "name:dan_x_preferred":[
@@ -262,6 +293,9 @@
     "name:gag_x_preferred":[
         "Sey\u015feller"
     ],
+    "name:gcr_x_preferred":[
+        "S\u00e9ch\u00e8l"
+    ],
     "name:gla_x_preferred":[
         "Na h-Eileanan Sheiseall"
     ],
@@ -278,6 +312,9 @@
     "name:glv_x_preferred":[
         "Ny h-Ellanyn Heshell"
     ],
+    "name:gpe_x_preferred":[
+        "Seychelles"
+    ],
     "name:grn_x_preferred":[
         "S\u00e9ichele"
     ],
@@ -289,6 +326,9 @@
     ],
     "name:guj_x_variant":[
         "\u0ab8\u0ac7\u0ab6\u0ac7\u0ab2\u0acd\u0ab8"
+    ],
+    "name:gur_x_preferred":[
+        "Seychelles"
     ],
     "name:hak_x_preferred":[
         "Seychelles"
@@ -461,6 +501,9 @@
     "name:lit_x_preferred":[
         "Sei\u0161eliai"
     ],
+    "name:lld_x_preferred":[
+        "Seychelles"
+    ],
     "name:lmo_x_preferred":[
         "Seychelles"
     ],
@@ -492,8 +535,14 @@
     "name:mar_x_preferred":[
         "\u0938\u0947\u0936\u0947\u0932\u094d\u0938"
     ],
+    "name:mdf_x_preferred":[
+        "\u0421\u044d\u0439\u0448\u044d\u043b\u0442\u043d\u0435"
+    ],
     "name:mhr_x_preferred":[
         "\u0421\u0435\u0439\u0448\u0435\u043b-\u0432\u043b\u0430\u043a"
+    ],
+    "name:min_x_preferred":[
+        "Seychelles"
     ],
     "name:mkd_x_preferred":[
         "\u0421\u0435\u0458\u0448\u0435\u043b\u0438"
@@ -506,6 +555,15 @@
     ],
     "name:mlt_x_preferred":[
         "Seychelles"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc1\uabe6\uabc6\uabe6\uabdc\uabc2\uabe6\uabc1"
+    ],
+    "name:mon_x_preferred":[
+        "\u0421\u0435\u0439\u0448\u0435\u043b\u0438\u0439\u043d \u0430\u0440\u043b\u0443\u0443\u0434"
+    ],
+    "name:mri_x_preferred":[
+        "Heikere"
     ],
     "name:mrj_x_preferred":[
         "\u0421\u0435\u0439\u0448\u0435\u043b\u0432\u043b\u04d3"
@@ -525,6 +583,9 @@
     "name:nan_x_preferred":[
         "Seychelles"
     ],
+    "name:nau_x_preferred":[
+        "Seychelles"
+    ],
     "name:nav_x_preferred":[
         "Seishel"
     ],
@@ -539,6 +600,12 @@
     ],
     "name:nep_x_preferred":[
         "\u0938\u0947\u091a\u0947\u0932\u0947\u0938"
+    ],
+    "name:nep_x_variant":[
+        "\u0938\u0947\u0938\u0947\u0932\u094d\u0938"
+    ],
+    "name:new_x_preferred":[
+        "\u0938\u093f\u0936\u0947\u0932\u094d\u0938"
     ],
     "name:nld_x_preferred":[
         "Seychellen"
@@ -647,6 +714,9 @@
     "name:sgs_x_preferred":[
         "Sei\u0161iel\u0113"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101e\u1031\u1038\u101e\u103b\u1084\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc3\u0dd3\u0dc2\u0dd9\u0dbd\u0dca\u0dc3\u0dca"
     ],
@@ -662,11 +732,23 @@
     "name:sme_x_preferred":[
         "Seychellsullot"
     ],
+    "name:sme_x_variant":[
+        "Seychellat"
+    ],
+    "name:smn_x_preferred":[
+        "Seychelleh"
+    ],
     "name:smo_x_preferred":[
         "Seychelles"
     ],
+    "name:sms_x_preferred":[
+        "Seychee\u02b9ll"
+    ],
     "name:sna_x_preferred":[
         "Seychelles"
+    ],
+    "name:snd_x_preferred":[
+        "\u0633\u064a\u0686\u064a\u0644\u064a\u0633"
     ],
     "name:som_x_preferred":[
         "Siishilis"
@@ -756,6 +838,9 @@
     "name:tuk_x_preferred":[
         "Se\u00fd\u015fel Adalary"
     ],
+    "name:tum_x_preferred":[
+        "Seychelles"
+    ],
     "name:tur_x_preferred":[
         "Sey\u015feller"
     ],
@@ -782,7 +867,8 @@
         "\u0633\u06cc\u0686\u06cc\u0644\u06cc\u0633"
     ],
     "name:urd_x_variant":[
-        "\u0633\u0634\u0644\u06cc\u0632"
+        "\u0633\u0634\u0644\u06cc\u0632",
+        "\u0633\u06cc\u0634\u06cc\u0644\u0632"
     ],
     "name:uzb_x_preferred":[
         "Seyshell orollari"
@@ -1066,7 +1152,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1617827406,
+    "wof:lastmodified":1690860401,
     "wof:name":"Seychelles",
     "wof:parent_id":102193527,
     "wof:placetype":"country",

--- a/data/856/782/37/85678237.geojson
+++ b/data/856/782/37/85678237.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0622\u0646\u0633\u064a-\u0623\u0648\u0643\u0633-\u0628\u064a\u0646\u0633"
     ],
+    "name:ast_x_preferred":[
+        "Anse aux Pins"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09a8\u09cd\u09b8- \u0986\u0989\u09b8 \u09aa\u09bf\u09a8\u09cd\u09b8"
     ],
@@ -97,6 +100,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc559\uc2a4\uc624\ud33d \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc559\uc2a4\uc624\ud33d\uad6c"
     ],
     "name:lav_x_preferred":[
         "Ansopina"
@@ -166,6 +172,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5b89\u585e\u5967\u6f58\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u6602\u65af\u6b27\u6f58\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"SYC",
@@ -287,7 +296,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495637,
+    "wof:lastmodified":1690860397,
     "wof:name":"Anse aux Pins",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/41/85678241.geojson
+++ b/data/856/782/41/85678241.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0646\u0633 \u0628\u0648\u064a\u0644\u0627\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Anse Boileau"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09a8\u09cd\u09b8 \u09ac\u09c1\u0987\u09b2\u09c1"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:eng_x_preferred":[
         "Anse Boileau"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0646\u0633\u0647 \u0628\u0648\u0626\u06cc\u0644\u0648"
     ],
     "name:fin_x_preferred":[
         "Anse Boileau"
@@ -91,6 +97,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc559\uc2a4\ubd80\uc54c\ub85c \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc559\uc2a4\ubd80\uc54c\ub85c\uad6c"
     ],
     "name:lav_x_preferred":[
         "Ansebualo"
@@ -280,7 +289,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495637,
+    "wof:lastmodified":1690860398,
     "wof:name":"Anse Boileau",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/47/85678247.geojson
+++ b/data/856/782/47/85678247.geojson
@@ -98,6 +98,9 @@
     "name:kor_x_preferred":[
         "\uc559\uc2a4\uc5d0\ud22c\uc54c \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc559\uc2a4\uc5d0\ud22c\uc54c\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Ansetol\u0113"
     ],
@@ -285,7 +288,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495638,
+    "wof:lastmodified":1690860398,
     "wof:name":"Anse Etoile",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/53/85678253.geojson
+++ b/data/856/782/53/85678253.geojson
@@ -92,6 +92,9 @@
     "name:kor_x_preferred":[
         "\uc624\uce74\ud504 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc624\uce74\ud504\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Aukapa"
     ],
@@ -278,7 +281,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495637,
+    "wof:lastmodified":1690860397,
     "wof:name":"Au Cap",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/57/85678257.geojson
+++ b/data/856/782/57/85678257.geojson
@@ -53,6 +53,9 @@
     "name:eng_x_preferred":[
         "Anse Royale"
     ],
+    "name:fas_x_preferred":[
+        "\u0622\u0646\u0633 \u0631\u0648\u06cc\u0627\u0644"
+    ],
     "name:fin_x_preferred":[
         "Anse Royale"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc559\uc2a4\ub8e8\uc544\uc584 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc559\uc2a4\ub8e8\uc544\uc584\uad6c"
     ],
     "name:lav_x_preferred":[
         "Ansurual\u0113"
@@ -277,7 +283,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495636,
+    "wof:lastmodified":1690860396,
     "wof:name":"Anse Royale",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/59/85678259.geojson
+++ b/data/856/782/59/85678259.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u09ac\u09be\u0987\u09af\u09bc\u09c7 \u09b2\u09be\u099c\u09be\u09b0"
     ],
+    "name:ben_x_variant":[
+        "\u09ac\u09c7 \u09b2\u09be\u099c\u09be\u09b0"
+    ],
     "name:cat_x_preferred":[
         "Baie Lazare"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:eng_x_preferred":[
         "Baie Lazare"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u06cc \u0644\u0627\u0632\u0627\u0631"
     ],
     "name:fin_x_preferred":[
         "Baie Lazare"
@@ -88,6 +94,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubca0\ub77c\uc790\ub974 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubca0\ub77c\uc790\ub974\uad6c"
     ],
     "name:lav_x_preferred":[
         "Belazare"
@@ -142,6 +151,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e1a\u0e22\u0e4c \u0e23\u0e32\u0e41\u0e0b\u0e22\u0e4c"
+    ],
+    "name:tha_x_variant":[
+        "\u0e41\u0e1a\u0e25\u0e32\u0e0b\u0e32\u0e23\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Baie Lazare"
@@ -278,7 +290,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495636,
+    "wof:lastmodified":1690860395,
     "wof:name":"Baie Lazare",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/65/85678265.geojson
+++ b/data/856/782/65/85678265.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u09ac\u09be\u0987\u09af\u09bc\u09c7 \u09b8\u09c7\u09a8\u09cd\u099f\u09c7 \u0986\u09a8\u09cd\u09af\u09c7"
     ],
+    "name:bul_x_preferred":[
+        "\u0411\u0435 \u0421\u0435\u043d\u0442 \u0410\u043d"
+    ],
     "name:cat_x_preferred":[
         "Baie Sainte Anne"
     ],
@@ -56,6 +59,9 @@
     "name:eng_x_variant":[
         "Baie Sainte Anne",
         "Baie Ste Anne"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u06cc \u0633\u0646\u062a \u0622\u0646"
     ],
     "name:fin_x_preferred":[
         "Baie Sainte Anne"
@@ -95,6 +101,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubca0\uc0dd\ud2b8\uc548 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubca0\uc0dd\ud2b8\uc548\uad6c"
     ],
     "name:lav_x_preferred":[
         "Besentanne"
@@ -278,7 +287,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495637,
+    "wof:lastmodified":1690860397,
     "wof:name":"Baie Sainte Anne",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/69/85678269.geojson
+++ b/data/856/782/69/85678269.geojson
@@ -68,6 +68,9 @@
     "name:guj_x_preferred":[
         "\u0aac\u0acd\u0aaf\u0ac1 \u0ab5\u0ac7\u0ab2\u0acb\u0aa8"
     ],
+    "name:hau_x_preferred":[
+        "Beau Vallon"
+    ],
     "name:heb_x_preferred":[
         "\u05d1\u05d5 \u05d5\u05d0\u05dc\u05d5\u05df"
     ],
@@ -94,6 +97,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubcf4\ubc1c\ub871 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubcf4\ubc1c\ub871\uad6c"
     ],
     "name:lav_x_preferred":[
         "Bevalonna"
@@ -283,7 +289,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495636,
+    "wof:lastmodified":1690860396,
     "wof:name":"Beau Vallon",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/73/85678273.geojson
+++ b/data/856/782/73/85678273.geojson
@@ -50,6 +50,9 @@
     "name:eng_x_preferred":[
         "Bel Air"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0644 \u0627\u06cc\u0631"
+    ],
     "name:fin_x_preferred":[
         "Bel Air"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubca8\uc5d0\ub974 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubca8\uc5d0\ub974\uad6c"
     ],
     "name:lav_x_preferred":[
         "Belaira"
@@ -272,7 +278,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495636,
+    "wof:lastmodified":1690860396,
     "wof:name":"Bel Air",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/77/85678277.geojson
+++ b/data/856/782/77/85678277.geojson
@@ -53,6 +53,9 @@
     "name:eng_x_variant":[
         "Bel Ombre"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0644 \u0627\u0648\u0645\u0628\u0631"
+    ],
     "name:fin_x_preferred":[
         "Bel Ombre"
     ],
@@ -91,6 +94,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubca8\uc634\ube0c\ub974 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubca8\uc634\ube0c\ub974\uad6c"
     ],
     "name:lav_x_preferred":[
         "Belombre"
@@ -142,6 +148,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0baa\u0bc6\u0bb2\u0bcd  \u0b92\u0bae\u0bcd\u0baa\u0bb0\u0bc7"
+    ],
+    "name:tam_x_variant":[
+        "\u0baa\u0bc6\u0bb2\u0bcd \u0b92\u0bae\u0bcd\u0baa\u0bb0\u0bc7"
     ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c46\u0c32\u0c4d \u0c13\u0c02\u0c2c\u0c4d\u0c30\u0c46"
@@ -283,7 +292,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495638,
+    "wof:lastmodified":1690860398,
     "wof:name":"Bel Ombre",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/83/85678283.geojson
+++ b/data/856/782/83/85678283.geojson
@@ -92,6 +92,9 @@
     "name:kor_x_preferred":[
         "\uce74\uc2a4\uce74\ub4dc \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uce74\uc2a4\uce74\ub4dc\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Kask\u0101de"
     ],
@@ -274,7 +277,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495637,
+    "wof:lastmodified":1690860398,
     "wof:name":"Cascade",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/87/85678287.geojson
+++ b/data/856/782/87/85678287.geojson
@@ -95,6 +95,9 @@
     "name:kor_x_preferred":[
         "\uae00\ub77c\uc2dc \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uae00\ub77c\uc2dc\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Gl\u0101sisa"
     ],
@@ -284,7 +287,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495637,
+    "wof:lastmodified":1690860396,
     "wof:name":"Glacis",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/91/85678291.geojson
+++ b/data/856/782/91/85678291.geojson
@@ -47,7 +47,8 @@
         "Grand'Anse"
     ],
     "name:fra_x_variant":[
-        "Grand$Anse"
+        "Grand$Anse",
+        "Grand Anse"
     ],
     "name:heb_x_preferred":[
         "\u05d2\u05e8\u05e0\u05d3'\u05d0\u05e0\u05e1"
@@ -70,6 +71,9 @@
     "name:kor_x_preferred":[
         "\uadf8\ub791\ub2f9\uc2a4\ub9c8\uc5d0 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uadf8\ub791\ub2f9\uc2a4\ub9c8\uc5d0\uad6c"
+    ],
     "name:msa_x_preferred":[
         "Grand'Anse Mah\u00e9"
     ],
@@ -79,8 +83,14 @@
     "name:pol_x_preferred":[
         "Grand' Anse"
     ],
+    "name:por_x_preferred":[
+        "Grand' Anse"
+    ],
     "name:ron_x_preferred":[
         "Districtul Grand'Anse Mah\u00e9"
+    ],
+    "name:rus_x_preferred":[
+        "\u0413\u0440\u0430\u043d\u0434-\u0410\u043d\u0441"
     ],
     "name:spa_x_preferred":[
         "Grand' Anse"
@@ -212,7 +222,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495637,
+    "wof:lastmodified":1690860397,
     "wof:name":"Grand'Anse",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/95/85678295.geojson
+++ b/data/856/782/95/85678295.geojson
@@ -95,6 +95,9 @@
     "name:kor_x_preferred":[
         "\uadf8\ub791\ub2f9\uc2a4\ud504\ub77c\uc2ac\ub7ad \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uadf8\ub791\ub2f9\uc2a4\ud504\ub77c\uc2ac\ub7ad\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Grandansepraslina"
     ],
@@ -142,6 +145,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bbf\u0bb0\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd '\u0b85\u0ba9\u0bcd\u0bb8\u0bcd \u0baa\u0bbf\u0bb0\u0bc6\u0bb8\u0bcd\u0bb2\u0bbf\u0ba9\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0b95\u0bbf\u0bb0\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd '\u0b85\u0ba9\u0bcd\u0bb8\u0bcd  \u0baa\u0bbf\u0bb0\u0bc6\u0bb8\u0bcd\u0bb2\u0bbf\u0ba9\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c17\u0c4d\u0c30\u0c3e\u0c02\u0c21\u0c4d\u0c06\u0c28\u0c4d\u0c38\u0c4d \u0c2a\u0c4d\u0c30\u0c3e\u0c38\u0c4d\u0c32\u0c3f\u0c28\u0c4d"
@@ -284,7 +290,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495636,
+    "wof:lastmodified":1690860395,
     "wof:name":"Grand'Anse Praslin",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/01/85678301.geojson
+++ b/data/856/783/01/85678301.geojson
@@ -50,6 +50,9 @@
     "name:eng_x_preferred":[
         "La Digue and Inner Islands"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0627 \u062f\u06cc\u06af\u0648 \u0648 \u062c\u0632\u0627\u06cc\u0631 \u067e\u0627\u06cc\u06cc\u0646\u06cc"
+    ],
     "name:fin_x_preferred":[
         "La Digue and Inner Islands"
     ],
@@ -106,6 +109,9 @@
     ],
     "name:por_x_preferred":[
         "Islas La Digue e Inner"
+    ],
+    "name:ron_x_preferred":[
+        "Districtul La Digue"
     ],
     "name:rus_x_preferred":[
         "\u041b\u0430-\u0414\u0438\u0433 \u0438 \u0412\u043d\u0443\u0442\u0440\u0435\u043d\u043d\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430"
@@ -267,7 +273,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495639,
+    "wof:lastmodified":1690860400,
     "wof:name":"La Digue and Inner Islands",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/05/85678305.geojson
+++ b/data/856/783/05/85678305.geojson
@@ -38,6 +38,9 @@
     "name:cat_x_preferred":[
         "La Riviere Anglaise"
     ],
+    "name:cat_x_variant":[
+        "La Rivi\u00e8re Anglaise"
+    ],
     "name:ceb_x_preferred":[
         "English River"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0631\u0648\u062f\u062e\u0627\u0646\u0647 \u0627\u0646\u06af\u0644\u06cc\u0633"
+    ],
+    "name:fas_x_variant":[
+        "\u0627\u0646\u06af\u0644\u06cc\u0634 \u0631\u06cc\u0648\u0631"
     ],
     "name:fin_x_preferred":[
         "La Rivi\u00e8re Anglaise"
@@ -94,6 +100,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub77c\ub9ac\ube44\uc5d0\ub974\uc559\uae00\ub808\uc988 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ub77c\ub9ac\ube44\uc5d0\ub974\uc559\uae00\ub808\uc988\uad6c"
     ],
     "name:lav_x_preferred":[
         "Ingli\u0161rivera"
@@ -278,7 +287,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495638,
+    "wof:lastmodified":1690860399,
     "wof:name":"English River",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/07/85678307.geojson
+++ b/data/856/783/07/85678307.geojson
@@ -53,6 +53,9 @@
     "name:eng_x_preferred":[
         "Mont Buxton"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0648\u0646\u062a \u0628\u0648\u06a9\u0633\u062a\u0648\u0646"
+    ],
     "name:fin_x_preferred":[
         "Mont Buxton"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubabd\ubdd5\uc2a4\ud1b5 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubabd\ubdd5\uc2a4\ud1b5\uad6c"
     ],
     "name:lav_x_preferred":[
         "Montbakstona"
@@ -275,7 +281,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495638,
+    "wof:lastmodified":1690860399,
     "wof:name":"Mont Buxton",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/11/85678311.geojson
+++ b/data/856/783/11/85678311.geojson
@@ -53,6 +53,9 @@
     "name:eng_x_preferred":[
         "Mont Fleuri"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0648\u0646\u062a \u0641\u0644\u0648\u0631\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Mont Fleuri"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubabd\ud50c\ub8b0\ub9ac \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubabd\ud50c\ub8b0\ub9ac\uad6c"
     ],
     "name:lav_x_preferred":[
         "Monfleri"
@@ -139,6 +145,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e19\u0e17\u0e4c \u0e40\u0e1f\u0e34\u0e25\u0e2d\u0e39\u0e23\u0e34"
+    ],
+    "name:tha_x_variant":[
+        "\u0e21\u0e07\u0e40\u0e1f\u0e25\u0e2d\u0e23\u0e35"
     ],
     "name:tur_x_preferred":[
         "Mont Fleuri"
@@ -275,7 +284,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495638,
+    "wof:lastmodified":1690860399,
     "wof:name":"Mont Fleuri",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/15/85678315.geojson
+++ b/data/856/783/15/85678315.geojson
@@ -56,6 +56,9 @@
     "name:fas_x_preferred":[
         "\u067e\u0644\u0633\u0627\u0646\u0633"
     ],
+    "name:fas_x_variant":[
+        "\u067e\u0644\u0632\u0627\u0633"
+    ],
     "name:fin_x_preferred":[
         "Plaisance"
     ],
@@ -91,6 +94,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud50c\ub808\uc7a5\uc2a4 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ud50c\ub808\uc7a5\uc2a4\uad6c"
     ],
     "name:lav_x_preferred":[
         "Plezanse"
@@ -278,7 +284,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495639,
+    "wof:lastmodified":1690860401,
     "wof:name":"Plaisance",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/23/85678323.geojson
+++ b/data/856/783/23/85678323.geojson
@@ -95,6 +95,9 @@
     "name:kor_x_preferred":[
         "\ud478\uc575\ud2b8\ub77c\ub8e8 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ud478\uc575\ud2b8\ub77c\ub8e8\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Puantlaru"
     ],
@@ -140,6 +143,9 @@
     "name:tam_x_preferred":[
         "\u0baa\u0bbe\u0baf\u0bbf\u0ba3\u0bcd\u0b9f\u0bcd \u0bb2\u0bbe \u0bb0\u0bc1\u0baf\u0bbf"
     ],
+    "name:tam_x_variant":[
+        "\u0baa\u0bbe\u0baf\u0bbf\u0ba3\u0bcd\u0b9f\u0bcd  \u0bb2\u0bbe \u0bb0\u0bc1\u0baf\u0bbf"
+    ],
     "name:tel_x_preferred":[
         "\u0c2a\u0c3e\u0c2f\u0c3f\u0c02\u0c1f\u0c4d \u0c32\u0c3e \u0c30\u0c4d\u0c2f\u0c42"
     ],
@@ -160,6 +166,9 @@
     ],
     "name:zho_x_preferred":[
         "\u666e\u5b89\u7279\u62c9\u5112\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u6f58\u7279\u62c9\u5415\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"SYC",
@@ -281,7 +290,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495639,
+    "wof:lastmodified":1690860401,
     "wof:name":"Pointe La Rue",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/25/85678325.geojson
+++ b/data/856/783/25/85678325.geojson
@@ -57,6 +57,9 @@
         "Pt Glaud",
         "Pt. Glaud"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0646\u062f\u0631 \u06af\u0644\u0648\u062f"
+    ],
     "name:fin_x_preferred":[
         "Port Glaud"
     ],
@@ -92,6 +95,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud3ec\ub974\uae00\ub85c\ub4dc \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ud3ec\ub974\uae00\ub85c\ub4dc\uad6c"
     ],
     "name:lav_x_preferred":[
         "Portglo"
@@ -155,6 +161,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6ce2\u7279\u683c\u52de\u5fb7\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u683c\u6d1b\u6e2f\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"SYC",
@@ -275,7 +284,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495639,
+    "wof:lastmodified":1690860401,
     "wof:name":"Port Glaud",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/31/85678331.geojson
+++ b/data/856/783/31/85678331.geojson
@@ -57,6 +57,9 @@
         "St Louis",
         "St. Louis"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0646\u062a \u0644\u0648\u0626\u06cc\u0633"
+    ],
     "name:fin_x_preferred":[
         "Saint Louis"
     ],
@@ -95,6 +98,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc0dd\ub8e8\uc774 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc0dd\ub8e8\uc774\uad6c"
     ],
     "name:lav_x_preferred":[
         "Sentluisa"
@@ -155,6 +161,9 @@
     ],
     "name:vie_x_preferred":[
         "Saint Louis"
+    ],
+    "name:yue_x_preferred":[
+        "\u8056\u8def\u6613\u65af"
     ],
     "name:zho_x_preferred":[
         "\u8056\u8def\u6613\u5340"
@@ -279,7 +288,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495639,
+    "wof:lastmodified":1690860399,
     "wof:name":"Saint Louis",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/33/85678333.geojson
+++ b/data/856/783/33/85678333.geojson
@@ -56,6 +56,9 @@
     "name:eng_x_preferred":[
         "Takamaka"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0627\u06a9\u0627\u0645\u0627\u06a9\u0627"
+    ],
     "name:fin_x_preferred":[
         "Takamaka"
     ],
@@ -91,6 +94,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud0c0\uce74\ub9c8\uce74 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ud0c0\uce74\ub9c8\uce74\uad6c"
     ],
     "name:lav_x_preferred":[
         "Takamaka"
@@ -280,7 +286,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495638,
+    "wof:lastmodified":1690860398,
     "wof:name":"Takamaka",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/39/85678339.geojson
+++ b/data/856/783/39/85678339.geojson
@@ -56,6 +56,9 @@
     "name:fas_x_preferred":[
         "\u0644\u0647 \u0645\u0645\u0644\u0632"
     ],
+    "name:fas_x_variant":[
+        "\u0644\u0647 \u0645\u0627\u0645\u0644"
+    ],
     "name:fin_x_preferred":[
         "Les Mamelles"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0ab2\u0ac7\u0ab8 \u0aae\u0ac7\u0aae\u0ac7\u0ab2\u0ac7\u0ab8"
+    ],
+    "name:heb_x_preferred":[
+        "\u05dc\u05d4 \u05de\u05de\u05dc"
     ],
     "name:hin_x_preferred":[
         "\u0932\u0940 \u092e\u0948\u092e\u0947\u0932\u0947\u0938"
@@ -88,6 +94,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub808\ub9c8\uba5c \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ub808\ub9c8\uba5c\uad6c"
     ],
     "name:lav_x_preferred":[
         "Lesmamelles"
@@ -151,6 +160,9 @@
     ],
     "name:zho_x_preferred":[
         "\u96f7\u746a\u9ea5\u723e\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u83b1\u9a6c\u6885\u52d2\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"SYC",
@@ -270,7 +282,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495639,
+    "wof:lastmodified":1690860400,
     "wof:name":"Les Mamelles",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/41/85678341.geojson
+++ b/data/856/783/41/85678341.geojson
@@ -6,8 +6,8 @@
     "edtf:inception":"uuuu",
     "geom:area":0.000131,
     "geom:area_square_m":1620103.234451,
-    "geom:bbox":"55.4749876036,-4.6585185408,55.4920254028,-4.63993763451",
-    "geom:latitude":-4.649382,
+    "geom:bbox":"55.474988,-4.658519,55.492025,-4.639938",
+    "geom:latitude":-4.649383,
     "geom:longitude":55.483181,
     "gn:population":3056,
     "iso:country":"SC",
@@ -56,6 +56,9 @@
     "name:eng_x_preferred":[
         "Roche Caiman"
     ],
+    "name:fas_x_preferred":[
+        "\u0631\u0648\u0634\u0647 \u06a9\u0627\u06cc\u0645\u0646"
+    ],
     "name:fin_x_preferred":[
         "Roche Caiman"
     ],
@@ -85,6 +88,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub85c\uc288\uce74\uc774\ub9dd \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ub85c\uc288\uce74\uc774\ub9dd\uad6c"
     ],
     "name:lav_x_preferred":[
         "Ro\u0161kaimana"
@@ -250,7 +256,7 @@
         "wk:page":"Roche Caiman"
     },
     "wof:country":"SC",
-    "wof:geomhash":"831c80d12c7e5ea951ae3599539cfc22",
+    "wof:geomhash":"4966ebd5dc72a31b995e856c614d7d0f",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -267,7 +273,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566638934,
+    "wof:lastmodified":1690860400,
     "wof:name":"Roche Ca\u00efman",
     "wof:parent_id":85632661,
     "wof:placetype":"region",
@@ -281,10 +287,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    55.47498760359508,
-    -4.65851854079796,
-    55.49202540275019,
-    -4.63993763451418
+    55.474988,
+    -4.658519,
+    55.492025,
+    -4.639938
 ],
-  "geometry": {"coordinates":[[[55.49202540275019,-4.65142783252838],[55.48947547671196,-4.65851854079796],[55.47498760359508,-4.64754287910057],[55.47566057617473,-4.63993763451418],[55.49202540275019,-4.65142783252838]]],"type":"Polygon"}
+  "geometry": {"coordinates":[[[55.492025,-4.651428],[55.489475,-4.658519],[55.474988,-4.647543],[55.475661,-4.639938],[55.492025,-4.651428]]],"type":"Polygon"}
 }


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.