### PR TITLE
sc concordances, placetype local, and more

### DIFF
--- a/data/856/326/61/85632661.geojson
+++ b/data/856/326/61/85632661.geojson
@@ -1121,6 +1121,7 @@
         "hasc:id":"SC",
         "icao:code":"S7",
         "ioc:id":"SEY",
+        "iso:code":"SC",
         "itu:id":"SEY",
         "loc:id":"n79071099",
         "m49:code":"690",
@@ -1134,6 +1135,7 @@
         "wk:page":"Seychelles",
         "wmo:id":"SC"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
     "wof:country_alpha3":"SYC",
     "wof:geom_alt":[
@@ -1156,7 +1158,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1694639511,
+    "wof:lastmodified":1695881166,
     "wof:name":"Seychelles",
     "wof:parent_id":102193527,
     "wof:placetype":"country",

--- a/data/856/782/33/85678233.geojson
+++ b/data/856/782/33/85678233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014787,
-    "geom:area_square_m":180463689.94203,
+    "geom:area_square_m":180462168.200109,
     "geom:bbox":"46.207367,-10.126072,56.287446,-5.42018",
     "geom:latitude":-9.234541,
     "geom:longitude":47.156068,
@@ -163,10 +163,12 @@
         "gn:id":-99,
         "gp:id":24549866,
         "hasc:id":"SC.OI",
+        "iso:code_pseudo":"SC-OO",
         "qs_pg:id":1191213
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"SC",
-    "wof:geomhash":"f8f89cc7b6c84953eafd022a70abcd61",
+    "wof:geomhash":"bb4fbfe88253102b425c8179be7b5eaa",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -183,7 +185,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636495636,
+    "wof:lastmodified":1695884804,
     "wof:name":"Outer Islands",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/37/85678237.geojson
+++ b/data/856/782/37/85678237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000152,
-    "geom:area_square_m":1872558.286416,
+    "geom:area_square_m":1872634.371146,
     "geom:bbox":"55.503963,-4.689128,55.528555,-4.677352",
     "geom:latitude":-4.682302,
     "geom:longitude":55.51772,
@@ -272,14 +272,16 @@
         "gn:id":241450,
         "gp:id":24549874,
         "hasc:id":"SC.PI",
+        "iso:code":"SC-01",
         "iso:id":"SC-01",
         "qs_pg:id":507457,
         "unlc:id":"SC-01",
         "wd:id":"Q569458",
         "wk:page":"Anse-aux-Pins"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"973eed6320d8e86960f22381ac1f6fe1",
+    "wof:geomhash":"9bc1e820903138507dc652004ef71351",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -296,7 +298,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860397,
+    "wof:lastmodified":1695884804,
     "wof:name":"Anse aux Pins",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/41/85678241.geojson
+++ b/data/856/782/41/85678241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001137,
-    "geom:area_square_m":14010624.720946,
+    "geom:area_square_m":14010560.835944,
     "geom:bbox":"55.478001,-4.739089,55.507947,-4.677836",
     "geom:latitude":-4.711478,
     "geom:longitude":55.494029,
@@ -266,13 +266,15 @@
         "gn:id":241449,
         "gp:id":24549869,
         "hasc:id":"SC.AB",
+        "iso:code":"SC-02",
         "iso:id":"SC-02",
         "qs_pg:id":507453,
         "unlc:id":"SC-02",
         "wd:id":"Q569453"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"c25f2dacd3791ab24c0f30e6dd924cd7",
+    "wof:geomhash":"debe5295d0a2229d9db191ac2a03b0cc",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -289,7 +291,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860398,
+    "wof:lastmodified":1695884804,
     "wof:name":"Anse Boileau",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/47/85678247.geojson
+++ b/data/856/782/47/85678247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000554,
-    "geom:area_square_m":6834016.817755,
+    "geom:area_square_m":6834021.790364,
     "geom:bbox":"55.439426,-4.604518,55.467221,-4.571384",
     "geom:latitude":-4.587537,
     "geom:longitude":55.452333,
@@ -265,13 +265,15 @@
         "gn:id":241447,
         "gp:id":24549884,
         "hasc:id":"SC.ET",
+        "iso:code":"SC-03",
         "iso:id":"SC-03",
         "qs_pg:id":59513,
         "wd:id":"Q387293",
         "wk:page":"Anse Etoile"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"dfbc95bdf648b6fb40ef3305c388b6cd",
+    "wof:geomhash":"b091d1bb4da9ea21cbeca6842d7f4899",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -288,7 +290,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860398,
+    "wof:lastmodified":1695884804,
     "wof:name":"Anse Etoile",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/53/85678253.geojson
+++ b/data/856/782/53/85678253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000933,
-    "geom:area_square_m":11499349.835713,
+    "geom:area_square_m":11499344.296567,
     "geom:bbox":"55.500189,-4.736832,55.528087,-4.679588",
     "geom:latitude":-4.705981,
     "geom:longitude":55.514551,
@@ -257,14 +257,16 @@
         "gn:id":448410,
         "gp:id":24549872,
         "hasc:id":"SC.LO",
+        "iso:code":"SC-04",
         "iso:id":"SC-04",
         "qs_pg:id":507455,
         "unlc:id":"SC-04",
         "wd:id":"Q2667004",
         "wk:page":"Au Cap"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"801443874966849f16e20aad6ad9a24b",
+    "wof:geomhash":"dea7f47ff7142a9ade57ac541d059acf",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -281,7 +283,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860397,
+    "wof:lastmodified":1695884804,
     "wof:name":"Au Cap",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/57/85678257.geojson
+++ b/data/856/782/57/85678257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000655,
-    "geom:area_square_m":8076176.432994,
+    "geom:area_square_m":8076209.900831,
     "geom:bbox":"55.504402,-4.771348,55.528087,-4.719832",
     "geom:latitude":-4.748952,
     "geom:longitude":55.513322,
@@ -260,13 +260,15 @@
         "gn:id":241444,
         "gp:id":24549870,
         "hasc:id":"SC.RO",
+        "iso:code":"SC-05",
         "iso:id":"SC-05",
         "qs_pg:id":507454,
         "unlc:id":"SC-05",
         "wd:id":"Q3241674"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"e74dadc910f047fb737b4c4d302962f3",
+    "wof:geomhash":"ccbe9e40310dfb7fb2f8ce5df14c3c99",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -283,7 +285,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860396,
+    "wof:lastmodified":1695884804,
     "wof:name":"Anse Royale",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/59/85678259.geojson
+++ b/data/856/782/59/85678259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001135,
-    "geom:area_square_m":13982612.903174,
+    "geom:area_square_m":13982402.266882,
     "geom:bbox":"55.46349,-4.777495,55.51011,-4.736364",
     "geom:latitude":-4.755431,
     "geom:longitude":55.48951,
@@ -266,14 +266,16 @@
         "gn:id":241439,
         "gp:id":24549868,
         "hasc:id":"SC.BL",
+        "iso:code":"SC-06",
         "iso:id":"SC-06",
         "qs_pg:id":219960,
         "unlc:id":"SC-06",
         "wd:id":"Q2494551",
         "wk:page":"Baie Lazare"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"ded740dfbc61179d5157955f941ad94d",
+    "wof:geomhash":"c99c9841dced7bf248c4947622987592",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -290,7 +292,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860395,
+    "wof:lastmodified":1695884804,
     "wof:name":"Baie Lazare",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/65/85678265.geojson
+++ b/data/856/782/65/85678265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001912,
-    "geom:area_square_m":23571209.379238,
+    "geom:area_square_m":23571193.707114,
     "geom:bbox":"55.68282,-4.350286,55.787038,-4.276841",
     "geom:latitude":-4.313792,
     "geom:longitude":55.738045,
@@ -264,13 +264,15 @@
         "gn:id":241438,
         "gp:id":24549888,
         "hasc:id":"SC.BS",
+        "iso:code":"SC-07",
         "iso:id":"SC-07",
         "qs_pg:id":1085975,
         "unlc:id":"SC-07",
         "wd:id":"Q803716"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"08433da16b4b723b5139a871498aca06",
+    "wof:geomhash":"e62aa52ea4a91853547ddc17bd648ca6",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -287,7 +289,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860397,
+    "wof:lastmodified":1695884804,
     "wof:name":"Baie Sainte Anne",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/69/85678269.geojson
+++ b/data/856/782/69/85678269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000475,
-    "geom:area_square_m":5855836.103956,
+    "geom:area_square_m":5855774.334116,
     "geom:bbox":"55.414422,-4.623835,55.440744,-4.586923",
     "geom:latitude":-4.604711,
     "geom:longitude":55.43087,
@@ -266,13 +266,15 @@
         "gn:id":241428,
         "gp:id":24549877,
         "hasc:id":"SC.BV",
+        "iso:code":"SC-08",
         "iso:id":"SC-08",
         "qs_pg:id":507460,
         "unlc:id":"SC-08",
         "wd:id":"Q7479348"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"c3b323020eae4fac7b99c241dfcfb43f",
+    "wof:geomhash":"9273eb258f66fe6d50664bac8225b2fa",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -289,7 +291,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860396,
+    "wof:lastmodified":1695884804,
     "wof:name":"Beau Vallon",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/73/85678273.geojson
+++ b/data/856/782/73/85678273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000634,
-    "geom:area_square_m":7810309.473102,
+    "geom:area_square_m":7810205.059172,
     "geom:bbox":"55.435036,-4.65764,55.464451,-4.618115",
     "geom:latitude":-4.637107,
     "geom:longitude":55.451383,
@@ -254,14 +254,16 @@
         "gn:id":241426,
         "gp:id":24549883,
         "hasc:id":"SC.BA",
+        "iso:code":"SC-09",
         "iso:id":"SC-09",
         "qs_pg:id":507466,
         "unlc:id":"SC-09",
         "wd:id":"Q815077",
         "wk:page":"Bel Air, Seychelles"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"ad1383031d54b3ea22d914040fd7ad4c",
+    "wof:geomhash":"4b58c79eb60bd70d1d124ace13ea9b78",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -278,7 +280,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860396,
+    "wof:lastmodified":1695884804,
     "wof:name":"Bel Air",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/77/85678277.geojson
+++ b/data/856/782/77/85678277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000819,
-    "geom:area_square_m":10092207.297641,
+    "geom:area_square_m":10092295.406617,
     "geom:bbox":"55.380478,-4.641397,55.431524,-4.612774",
     "geom:latitude":-4.625823,
     "geom:longitude":55.407039,
@@ -269,13 +269,15 @@
         "gn:id":241424,
         "gp:id":24549890,
         "hasc:id":"SC.BO",
+        "iso:code":"SC-10",
         "iso:id":"SC-10",
         "qs_pg:id":59690,
         "unlc:id":"SC-10",
         "wd:id":"Q3245439"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"c30d0793d1c833f7149d262fc3f01fce",
+    "wof:geomhash":"25767ec41cea629d7eb5a435f9db2f94",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -292,7 +294,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860398,
+    "wof:lastmodified":1695884804,
     "wof:name":"Bel Ombre",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/83/85678283.geojson
+++ b/data/856/782/83/85678283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000461,
-    "geom:area_square_m":5684793.232405,
+    "geom:area_square_m":5684821.994863,
     "geom:bbox":"55.482724,-4.680909,55.513646,-4.651428",
     "geom:latitude":-4.666787,
     "geom:longitude":55.49835,
@@ -254,13 +254,15 @@
         "gn:id":241396,
         "gp:id":24549871,
         "hasc:id":"SC.CA",
+        "iso:code":"SC-11",
         "iso:id":"SC-11",
         "qs_pg:id":59687,
         "unlc:id":"SC-11",
         "wd:id":"Q1928685"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"35879cfc4a1eff9e20a76eb9c2fd2bb5",
+    "wof:geomhash":"63f357b20bc42b065a45c95abad3d2bf",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -277,7 +279,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860398,
+    "wof:lastmodified":1695884804,
     "wof:name":"Cascade",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/87/85678287.geojson
+++ b/data/856/782/87/85678287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000476,
-    "geom:area_square_m":5868703.781012,
+    "geom:area_square_m":5868704.926666,
     "geom:bbox":"55.432687,-4.586957,55.46386,-4.560511",
     "geom:latitude":-4.571567,
     "geom:longitude":55.44512,
@@ -263,14 +263,16 @@
         "gn:id":241336,
         "gp:id":24549878,
         "hasc:id":"SC.GL",
+        "iso:code":"SC-12",
         "iso:id":"SC-12",
         "qs_pg:id":507461,
         "unlc:id":"SC-12",
         "wd:id":"Q3241696",
         "wk:page":"Glacis, Seychelles"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"82ab6b9aacab7ec42e604abad9dc410c",
+    "wof:geomhash":"5af41e46937a9ab8d60347a0ba55a2fe",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -287,7 +289,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860396,
+    "wof:lastmodified":1695884804,
     "wof:name":"Glacis",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/91/85678291.geojson
+++ b/data/856/782/91/85678291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001357,
-    "geom:area_square_m":16723269.232233,
+    "geom:area_square_m":16723532.399384,
     "geom:bbox":"55.446451,-4.706406,55.495183,-4.65764",
     "geom:latitude":-4.681087,
     "geom:longitude":55.471009,
@@ -199,13 +199,15 @@
         "gn:id":241330,
         "gp:id":24549875,
         "hasc:id":"SC.GM",
+        "iso:code":"SC-13",
         "iso:id":"SC-13",
         "qs_pg:id":507458,
         "wd:id":"Q3241690",
         "wk:page":"Grand'Anse Mah\u00e9"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"84e8b4d189cdfb81865ef47b51b1ab5c",
+    "wof:geomhash":"691533572e5689c0f08f36d7851d5b0f",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -222,7 +224,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860397,
+    "wof:lastmodified":1695884804,
     "wof:name":"Grand'Anse",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/782/95/85678295.geojson
+++ b/data/856/782/95/85678295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001872,
-    "geom:area_square_m":23085375.77644,
+    "geom:area_square_m":23085552.656775,
     "geom:bbox":"55.643668,-4.358425,55.767995,-4.209909",
     "geom:latitude":-4.325962,
     "geom:longitude":55.717048,
@@ -266,14 +266,16 @@
         "gn:id":241331,
         "gp:id":24549889,
         "hasc:id":"SC.GP",
+        "iso:code":"SC-14",
         "iso:id":"SC-14",
         "qs_pg:id":896542,
         "unlc:id":"SC-14",
         "wd:id":"Q1231388",
         "wk:page":"Grand'Anse Praslin"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"4f136d97ed458064fe8306edd695ee49",
+    "wof:geomhash":"3f41517e90098e7909f548ffab788a50",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -290,7 +292,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860395,
+    "wof:lastmodified":1695884804,
     "wof:name":"Grand'Anse Praslin",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/01/85678301.geojson
+++ b/data/856/783/01/85678301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003345,
-    "geom:area_square_m":41241615.723227,
+    "geom:area_square_m":41241502.245718,
     "geom:bbox":"55.221446,-4.592755,55.950144,-3.791111",
     "geom:latitude":-4.406277,
     "geom:longitude":55.516602,
@@ -251,12 +251,14 @@
         "gn:id":241311,
         "gp:id":-99,
         "hasc:id":"SC.DI",
+        "iso:code":"SC-15",
         "iso:id":"SC-15",
         "unlc:id":"SC-15",
         "wd:id":"Q1094917"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"5efb6fd5b36ad447b6947ba96a67ca68",
+    "wof:geomhash":"68b9dde28b9ed10911a8db7a50385360",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -273,7 +275,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860400,
+    "wof:lastmodified":1695884804,
     "wof:name":"La Digue and Inner Islands",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/05/85678305.geojson
+++ b/data/856/783/05/85678305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000281,
-    "geom:area_square_m":3465569.283957,
+    "geom:area_square_m":3465547.774546,
     "geom:bbox":"55.440744,-4.620762,55.459937,-4.597494",
     "geom:latitude":-4.60837,
     "geom:longitude":55.452596,
@@ -264,13 +264,15 @@
         "gn:id":241302,
         "gp:id":24549885,
         "hasc:id":"SC.RA",
+        "iso:code":"SC-16",
         "iso:id":"SC-16",
         "qs_pg:id":354728,
         "wd:id":"Q1819963",
         "wk:page":"La Rivi\u00e8re Anglaise"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"5fce2bf1eede2f2c230ae399d9ce58cb",
+    "wof:geomhash":"713819bb6643e334f45ea43195057f08",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -287,7 +289,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860399,
+    "wof:lastmodified":1695884804,
     "wof:name":"English River",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/07/85678307.geojson
+++ b/data/856/783/07/85678307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00011,
-    "geom:area_square_m":1360032.430189,
+    "geom:area_square_m":1360087.499771,
     "geom:bbox":"55.435914,-4.620762,55.448646,-4.604518",
     "geom:latitude":-4.612418,
     "geom:longitude":55.442599,
@@ -257,14 +257,16 @@
         "gn:id":241252,
         "gp:id":24549887,
         "hasc:id":"SC.MB",
+        "iso:code":"SC-17",
         "iso:id":"SC-17",
         "qs_pg:id":59689,
         "unlc:id":"SC-17",
         "wd:id":"Q3241682",
         "wk:page":"Mont Buxton"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"55d68114eab2488c52424c6c7d08d8bb",
+    "wof:geomhash":"286c13c6deb29574d60575f01c6172d3",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -281,7 +283,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860399,
+    "wof:lastmodified":1695884804,
     "wof:name":"Mont Buxton",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/11/85678311.geojson
+++ b/data/856/783/11/85678311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000521,
-    "geom:area_square_m":6422930.332488,
+    "geom:area_square_m":6422936.005386,
     "geom:bbox":"55.455231,-4.647104,55.514426,-4.598366",
     "geom:latitude":-4.623544,
     "geom:longitude":55.489591,
@@ -260,14 +260,16 @@
         "gn:id":241251,
         "gp:id":24549882,
         "hasc:id":"SC.MF",
+        "iso:code":"SC-18",
         "iso:id":"SC-18",
         "qs_pg:id":507465,
         "unlc:id":"SC-18",
         "wd:id":"Q1945413",
         "wk:page":"Mont Fleuri"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"60e4b50bec093318c28b0ef6dcf9e84e",
+    "wof:geomhash":"f65076f5f18e9c5e06036cb28aa0b316",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -284,7 +286,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860399,
+    "wof:lastmodified":1695884804,
     "wof:name":"Mont Fleuri",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/15/85678315.geojson
+++ b/data/856/783/15/85678315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000338,
-    "geom:area_square_m":4161028.134719,
+    "geom:area_square_m":4160974.413465,
     "geom:bbox":"55.459183,-4.672128,55.479817,-4.634917",
     "geom:latitude":-4.653491,
     "geom:longitude":55.470028,
@@ -260,14 +260,16 @@
         "gn:id":241224,
         "gp:id":24549881,
         "hasc:id":"SC.PL",
+        "iso:code":"SC-19",
         "iso:id":"SC-19",
         "qs_pg:id":507464,
         "unlc:id":"SC-19",
         "wd:id":"Q2199897",
         "wk:page":"Plaisance, Seychelles"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"4e1db0a44071a7628a96840f85f8ab3a",
+    "wof:geomhash":"be5d8285922c3f8c2b078dd15c47d824",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -284,7 +286,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860401,
+    "wof:lastmodified":1695884804,
     "wof:name":"Plaisance",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/23/85678323.geojson
+++ b/data/856/783/23/85678323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00014,
-    "geom:area_square_m":1728146.257097,
+    "geom:area_square_m":1728082.297571,
     "geom:bbox":"55.506301,-4.680193,55.528555,-4.666174",
     "geom:latitude":-4.674453,
     "geom:longitude":55.516297,
@@ -266,14 +266,16 @@
         "gn:id":241221,
         "gp:id":24549873,
         "hasc:id":"SC.PR",
+        "iso:code":"SC-20",
         "iso:id":"SC-20",
         "qs_pg:id":507456,
         "unlc:id":"SC-20",
         "wd:id":"Q2877260",
         "wk:page":"Pointe La Rue"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"7f95b28bfa2f1b85ac9d406973f0b892",
+    "wof:geomhash":"af30d073ac618571b52a2fb478d1e099",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -290,7 +292,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860401,
+    "wof:lastmodified":1695884804,
     "wof:name":"Pointe La Rue",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/25/85678325.geojson
+++ b/data/856/783/25/85678325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002361,
-    "geom:area_square_m":29095472.291627,
+    "geom:area_square_m":29095712.899948,
     "geom:bbox":"55.360512,-4.680292,55.459183,-4.623835",
     "geom:latitude":-4.650916,
     "geom:longitude":55.417012,
@@ -261,13 +261,15 @@
         "gn:id":241215,
         "gp:id":24549876,
         "hasc:id":"SC.PG",
+        "iso:code":"SC-21",
         "iso:id":"SC-21",
         "qs_pg:id":507459,
         "unlc:id":"SC-21",
         "wd:id":"Q1808165"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"f9cfbbff4e5c47cbe037839adc1fade3",
+    "wof:geomhash":"b63afe98b71627b8e2bef9844b513567",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -284,7 +286,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860401,
+    "wof:lastmodified":1695884805,
     "wof:name":"Port Glaud",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/31/85678331.geojson
+++ b/data/856/783/31/85678331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000116,
-    "geom:area_square_m":1430091.600749,
+    "geom:area_square_m":1430111.201406,
     "geom:bbox":"55.431524,-4.630421,55.447329,-4.615055",
     "geom:latitude":-4.62242,
     "geom:longitude":55.438554,
@@ -264,14 +264,16 @@
         "gn:id":241181,
         "gp:id":24549886,
         "hasc:id":"SC.SL",
+        "iso:code":"SC-22",
         "iso:id":"SC-22",
         "qs_pg:id":59688,
         "unlc:id":"SC-22",
         "wd:id":"Q2278695",
         "wk:page":"Saint Louis, Seychelles"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"21fd325f4075e338798383bf09969e6f",
+    "wof:geomhash":"82190acaceb5c4fd5bb4c97461bf199c",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -288,7 +290,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860399,
+    "wof:lastmodified":1695884805,
     "wof:name":"Saint Louis",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/33/85678333.geojson
+++ b/data/856/783/33/85678333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000904,
-    "geom:area_square_m":11140576.822217,
+    "geom:area_square_m":11140636.155907,
     "geom:bbox":"55.493209,-4.803769,55.537916,-4.770066",
     "geom:latitude":-4.787913,
     "geom:longitude":55.517304,
@@ -263,13 +263,15 @@
         "gn:id":241151,
         "gp:id":24549867,
         "hasc:id":"SC.TA",
+        "iso:code":"SC-23",
         "iso:id":"SC-23",
         "qs_pg:id":59686,
         "unlc:id":"SC-23",
         "wd:id":"Q2287379"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"2995902674bdbd02ee74cce95946cd9e",
+    "wof:geomhash":"397c55938f0497e81c31657bcd789398",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -286,7 +288,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860398,
+    "wof:lastmodified":1695884804,
     "wof:name":"Takamaka",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/39/85678339.geojson
+++ b/data/856/783/39/85678339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000125,
-    "geom:area_square_m":1543926.67573,
+    "geom:area_square_m":1543833.281942,
     "geom:bbox":"55.47411,-4.665148,55.489475,-4.647543",
     "geom:latitude":-4.657146,
     "geom:longitude":55.480206,
@@ -259,13 +259,15 @@
         "gn:id":448408,
         "gp:id":24549880,
         "hasc:id":"SC.LM",
+        "iso:code":"SC-24",
         "iso:id":"SC-24",
         "qs_pg:id":507463,
         "wd:id":"Q2280357",
         "wk:page":"Les Mamelles"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"d1ec9c9ec0fcf0ca5110b5ce0ac7ef92",
+    "wof:geomhash":"a983296004935212b165aee987619bed",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -282,7 +284,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860400,
+    "wof:lastmodified":1695884805,
     "wof:name":"Les Mamelles",
     "wof:parent_id":85632661,
     "wof:placetype":"region",

--- a/data/856/783/41/85678341.geojson
+++ b/data/856/783/41/85678341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000131,
-    "geom:area_square_m":1620103.234451,
+    "geom:area_square_m":1620039.163259,
     "geom:bbox":"55.474988,-4.658519,55.492025,-4.639938",
     "geom:latitude":-4.649383,
     "geom:longitude":55.483181,
@@ -250,13 +250,15 @@
         "gn:id":448409,
         "gp:id":24549879,
         "hasc:id":"SC.RC",
+        "iso:code":"SC-25",
         "iso:id":"SC-25",
         "qs_pg:id":507462,
         "wd:id":"Q2718315",
         "wk:page":"Roche Caiman"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SC",
-    "wof:geomhash":"4966ebd5dc72a31b995e856c614d7d0f",
+    "wof:geomhash":"9f014550f99a041462ee223fff102979",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -273,7 +275,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860400,
+    "wof:lastmodified":1695884326,
     "wof:name":"Roche Ca\u00efman",
     "wof:parent_id":85632661,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.